### PR TITLE
LNT: Explicit optional

### DIFF
--- a/msal_requests_auth/auth/device_code.py
+++ b/msal_requests_auth/auth/device_code.py
@@ -3,7 +3,7 @@ Module for handling the Device Code flow with MSAL and credential refresh.
 """
 import os
 import webbrowser
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pyperclip
 from msal import PublicClientApplication
@@ -22,7 +22,7 @@ class DeviceCodeAuth(BaseMSALRefreshAuth):
         self,
         client: PublicClientApplication,
         scopes: List[str],
-        headless: bool = None,
+        headless: Optional[bool] = None,
     ):
         """
         .. versionadded:: 0.2.0 headless


### PR DESCRIPTION
```
msal_requests_auth/auth/device_code.py:25: error: Incompatible default for argument "headless" (default has type "None", argument has type "bool")  [assignment]
msal_requests_auth/auth/device_code.py:25: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
```