### PR TITLE
BUG: Remove __del__ method from cache

### DIFF
--- a/msal_requests_auth/cache.py
+++ b/msal_requests_auth/cache.py
@@ -24,9 +24,6 @@ class _BaseTokenCache(ABC, SerializableTokenCache):
         """
         raise NotImplementedError
 
-    def __del__(self):
-        self.write_cache()
-
     def __enter__(self):
         return self
 


### PR DESCRIPTION
Causing unstable behavior & doesn't improve much: https://github.com/corteva/msal-requests-auth/actions/runs/5612333261/job/15205993806

Also, should use the `with` statement as recommended anyway.