### PR TITLE
ENH: Add get_access_token method to clients

### DIFF
--- a/msal_requests_auth/auth/base_auth_client.py
+++ b/msal_requests_auth/auth/base_auth_client.py
@@ -45,6 +45,20 @@ class BaseMSALRefreshAuth(requests.auth.AuthBase):
         """
         Adds the token to the authorization header.
         """
+        token = self.get_access_token()
+        input_request.headers[
+            "Authorization"
+        ] = f"{token['token_type']} {token['access_token']}"
+        return input_request
+
+    def get_access_token(self) -> Dict[str, str]:
+        """
+        Retrieves the token dictionary from Azure AD.
+
+        Returns
+        -------
+        dict
+        """
         token = self._get_access_token()
         if "access_token" not in token:
             error = token.get("error")
@@ -52,15 +66,12 @@ class BaseMSALRefreshAuth(requests.auth.AuthBase):
             raise AuthenticationError(
                 f"Unable to get token. Error: {error} (Details: {description})."
             )
-        input_request.headers[
-            "Authorization"
-        ] = f"{token['token_type']} {token['access_token']}"
-        return input_request
+        return token
 
     @abstractmethod
     def _get_access_token(self) -> Dict[str, str]:
         """
-        Retrieves the token dictionary from Azure AD.
+        Abstract method to return the token dictionary from Azure AD.
 
         Returns
         -------

--- a/test/test_client_credential.py
+++ b/test/test_client_credential.py
@@ -7,6 +7,42 @@ from msal_requests_auth.exceptions import AuthenticationError
 
 
 @patch("msal.ConfidentialClientApplication", autospec=True)
+@patch(
+    "msal_requests_auth.auth.client_credential.ClientCredentialAuth._get_access_token"
+)
+def test_client_credential_auth__get_access_token__error(access_token_mock, cca_mock):
+    access_token_mock.return_value = {
+        "error": "BAD REQUEST",
+        "error_description": "Request to get token was bad.",
+    }
+    with pytest.raises(
+        AuthenticationError,
+        match=(
+            r"Unable to get token\. Error: BAD REQUEST "
+            r"\(Details: Request to get token was bad\.\)\."
+        ),
+    ):
+        ClientCredentialAuth(client=cca_mock, scopes=["TEST SCOPE"]).get_access_token()
+
+
+@patch("msal.ConfidentialClientApplication", autospec=True)
+@patch(
+    "msal_requests_auth.auth.client_credential.ClientCredentialAuth._get_access_token"
+)
+def test_client_credential_auth__get_access_token__valid(access_token_mock, cca_mock):
+    access_token_mock.return_value = {
+        "token_type": "Bearer",
+        "access_token": "TEST TOKEN",
+    }
+    assert ClientCredentialAuth(
+        client=cca_mock, scopes=["TEST SCOPE"]
+    ).get_access_token() == {
+        "token_type": "Bearer",
+        "access_token": "TEST TOKEN",
+    }
+
+
+@patch("msal.ConfidentialClientApplication", autospec=True)
 def test_client_credential_auth__no_cache(cca_mock):
     cca_mock.acquire_token_silent.return_value = None
     cca_mock.acquire_token_for_client.return_value = {


### PR DESCRIPTION
Seen usage of `_get_access_token` and was thinking a public method would be useful.